### PR TITLE
chore: change sh to bash

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -28,7 +28,7 @@ scoop install nitric
 `nitric` can be downloaded as a scripted install via curl.
 
 ```bash
-curl https://nitric.io/install | sh
+curl https://nitric.io/install | bash
 ```
 
 ### Manual


### PR DESCRIPTION
Error received if sh is used with #!/bin/sh as a comment in install file.