### PR TITLE
feat: Add api middleware information to base API docs to increase visibility

### DIFF
--- a/docs/apis/_index.md
+++ b/docs/apis/_index.md
@@ -124,6 +124,45 @@ galaxyApi.get('planets/unsecured-planet', async (ctx) => {}, {
 });
 ```
 
+## Defining Middleware
+
+APIs support middleware at the API level and at the route level. Middleware is supplied both a `HttpContext` object and a `next()` function which calls the next middleware in the chain.
+
+```javascript
+const validate = (ctx, next) => {
+  // Do request validation, etc.
+  next();
+}
+```
+
+### API level middleware
+
+Middleware defined at the API level will be called on every route.
+
+```javascript
+import { api } from '@nitric/sdk';
+import { validate, logRequest } from '../middleware';
+
+const customersApi = api('customers', {
+  middleware: [logRequest, validate], 
+});
+```
+
+### Route level middleware
+
+Middleware defined at a route level will only be called for that route.
+
+```javascript
+import { api } from '@nitric/sdk';
+import { validate } from '../middleware';
+
+const customersApi = api('customers');
+
+const getAllCustomers = (ctx) => {};
+
+customersApi.get('/customers', validate, getAllCustomers);
+```
+
 ## What's next?
 
 - Learn more about APIs in our [reference docs](/docs/reference/api/api).

--- a/docs/apis/_index.md
+++ b/docs/apis/_index.md
@@ -132,7 +132,7 @@ APIs support middleware at the API level and at the route level. Middleware is s
 const validate = (ctx, next) => {
   // Do request validation, etc.
   next();
-}
+};
 ```
 
 ### API level middleware
@@ -144,7 +144,7 @@ import { api } from '@nitric/sdk';
 import { validate, logRequest } from '../middleware';
 
 const customersApi = api('customers', {
-  middleware: [logRequest, validate], 
+  middleware: [logRequest, validate],
 });
 ```
 

--- a/docs/reference/api/api-route-all.mdx
+++ b/docs/reference/api/api-route-all.mdx
@@ -3,13 +3,13 @@ Register a single handler for all HTTP Methods (GET, POST, PUT, DELETE, PATCH) o
 ```javascript
 import { api } from '@nitric/sdk';
 
-const customersRoute = api('public').route('/customers')
+const customersRoute = api('public').route('/customers');
 
 customersRoute.all((ctx) => {
   // construct a response for all incoming HTTP requests
   const responseBody = {};
   ctx.res.json(responseBody);
-})
+});
 ```
 
 ## Parameters

--- a/docs/reference/api/api-route-all.mdx
+++ b/docs/reference/api/api-route-all.mdx
@@ -5,7 +5,7 @@ import { api } from '@nitric/sdk';
 
 const customersRoute = api('public').route('/customers')
 
-customersRoute.all(ctx) => {
+customersRoute.all((ctx) => {
   // construct a response for all incoming HTTP requests
   const responseBody = {};
   ctx.res.json(responseBody);


### PR DESCRIPTION
Meant as a solution to this issue:
https://github.com/nitrictech/node-sdk/issues/117

Don't need to do Auth Middleware in particular, as the api security definitions is now an included feature in base APIs.