### PR TITLE
Add stack configuration docs.

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -45,6 +45,7 @@ fasthttp
 filepath
 firestore
 gcloud
+gcp
 github
 homebrew
 integrations

--- a/doc.config.json
+++ b/doc.config.json
@@ -30,6 +30,15 @@
               {
                 "title": "Deployment",
                 "path": "/docs/deployment/_index.md"
+              },
+              {
+                "title": "Configuration",
+                "routes": [
+                  {
+                    "title": "Stacks",
+                    "path": "/docs/config/stack.md"
+                  }
+                ]
               }
             ]
           },

--- a/docs/config/stack.md
+++ b/docs/config/stack.md
@@ -18,3 +18,4 @@ functions:
     memory: 1024
     timeout: 15
 ```
+> This configuration goes in the stack file e.g. `nitric-<stack>.yaml`

--- a/docs/config/stack.md
+++ b/docs/config/stack.md
@@ -18,6 +18,7 @@ functions:
     memory: 1024
     timeout: 15
 ```
+
 > This configuration goes in the stack file e.g. `nitric-<stack>.yaml`
 
 ### Default values

--- a/docs/config/stack.md
+++ b/docs/config/stack.md
@@ -1,6 +1,5 @@
 ## Stack Configuration
 
-
 ### Function Config
 
 Functions can be configured with memory and timeout requirements per function, a default can also be set for all functions in a stack that do not have their own configuration.
@@ -9,14 +8,13 @@ Functions can be configured with memory and timeout requirements per function, a
 
 ```yaml
 functions:
-    default:
-        # Set functions to have 512 MB of memory
-        memory: 512
-        # Set functions to have a timeout of 30 seconds
-        timeout: 30
-    # Set the memory and timeout for a specific function
-    functions/hello-world.ts:
-        memory: 1024
-        timeout: 15
+  default:
+    # Set functions to have 512 MB of memory
+    memory: 512
+    # Set functions to have a timeout of 30 seconds
+    timeout: 30
+  # Set the memory and timeout for a specific function
+  functions/hello-world.ts:
+    memory: 1024
+    timeout: 15
 ```
-

--- a/docs/config/stack.md
+++ b/docs/config/stack.md
@@ -23,7 +23,7 @@ functions:
 
 ### Default values
 
-When function configuration is not specfied the default depends on on the cloud provider being deployed to:
+When function configuration is not specified the default depends on the cloud provider being deployed to:
 
 | provider | memory | timeout |
 | -------- | ------ | ------- |

--- a/docs/config/stack.md
+++ b/docs/config/stack.md
@@ -1,0 +1,22 @@
+## Stack Configuration
+
+
+### Function Config
+
+Functions can be configured with memory and timeout requirements per function, a default can also be set for all functions in a stack that do not have their own configuration.
+
+**Example**
+
+```yaml
+functions:
+    default:
+        # Set functions to have 512 MB of memory
+        memory: 512
+        # Set functions to have a timeout of 30 seconds
+        timeout: 30
+    # Set the memory and timeout for a specific function
+    functions/hello-world.ts:
+        memory: 1024
+        timeout: 15
+```
+

--- a/docs/config/stack.md
+++ b/docs/config/stack.md
@@ -19,3 +19,13 @@ functions:
     timeout: 15
 ```
 > This configuration goes in the stack file e.g. `nitric-<stack>.yaml`
+
+### Default values
+
+When function configuration is not specfied the default depends on on the cloud provider being deployed to:
+
+| provider | memory | timeout |
+| -------- | ------ | ------- |
+| aws      | 128    | 15      |
+| gcp      | 512    | 15      |
+| azure    | 128    | 15      |


### PR DESCRIPTION
Add configuration docs for stacks to our existing docs, these are currently under overview but there is probably a better place to put them.

Do we also want to include documentation for individual providers as well?

And should we add placeholder configuration to our templates?