### PR TITLE
feat: csharp bucket notification docs

### DIFF
--- a/docs/reference/csharp/v0/api/api-delete.md
+++ b/docs/reference/csharp/v0/api/api-delete.md
@@ -1,6 +1,6 @@
 ---
-title: api.delete()
-description: Register an API route and set a specific HTTP DELETE handler on that route.
+title: .NET - api.delete()
+description: Reference for Nitric's .NET library - Register an API route and set a specific HTTP DELETE handler on that route.
 ---
 
 Register an API route and set a specific HTTP DELETE handler on that route.

--- a/docs/reference/csharp/v0/api/api-get.md
+++ b/docs/reference/csharp/v0/api/api-get.md
@@ -1,6 +1,6 @@
 ---
-title: api.get()
-description: Register an API route and set a specific HTTP GET handler on that route.
+title: .NET - api.get()
+description: Reference for Nitric's .NET library - Register an API route and set a specific HTTP GET handler on that route.
 ---
 
 Register an API route and set a specific HTTP GET handler on that route.

--- a/docs/reference/csharp/v0/api/api-patch.md
+++ b/docs/reference/csharp/v0/api/api-patch.md
@@ -1,6 +1,6 @@
 ---
-title: api.patch()
-description: Register an API route and set a specific HTTP PATCH handler on that route.
+title: .NET - api.patch()
+description: Reference for Nitric's .NET library - Register an API route and set a specific HTTP PATCH handler on that route.
 ---
 
 Register an API route and set a specific HTTP PATCH handler on that route.

--- a/docs/reference/csharp/v0/api/api-post.md
+++ b/docs/reference/csharp/v0/api/api-post.md
@@ -1,6 +1,6 @@
 ---
-title: api.post()
-description: Register an API route and set a specific HTTP POST handler on that route.
+title: .NET - api.post()
+description: Reference for Nitric's .NET library - Register an API route and set a specific HTTP POST handler on that route.
 ---
 
 Register an API route and set a specific HTTP POST handler on that route.

--- a/docs/reference/csharp/v0/api/api-put.md
+++ b/docs/reference/csharp/v0/api/api-put.md
@@ -1,6 +1,6 @@
 ---
-title: api.put()
-description: Register an API route and set a specific HTTP PUT handler on that route.
+title: .NET - api.put()
+description: Reference for Nitric's .NET library - Register an API route and set a specific HTTP PUT handler on that route.
 ---
 
 Register an API route and set a specific HTTP PUT handler on that route.

--- a/docs/reference/csharp/v0/api/api-route-all.md
+++ b/docs/reference/csharp/v0/api/api-route-all.md
@@ -1,6 +1,6 @@
 ---
-title: api.route.all()
-description: Register a single handler for all HTTP Methods (GET, POST, PUT, DELETE, PATCH) on the route.
+title: .NET - api.route.all()
+description: Reference for Nitric's .NET library - Register a single handler for all HTTP Methods (GET, POST, PUT, DELETE, PATCH) on the route.
 ---
 
 Register a single handler for all HTTP Methods (GET, POST, PUT, DELETE, PATCH) on the route.

--- a/docs/reference/csharp/v0/api/api-route-delete.md
+++ b/docs/reference/csharp/v0/api/api-route-delete.md
@@ -1,6 +1,6 @@
 ---
-title: api.route.delete()
-description: Register a handler for HTTP DELETE requests to the route.
+title: .NET - api.route.delete()
+description: Reference for Nitric's .NET library - Register a handler for HTTP DELETE requests to the route.
 ---
 
 Register a handler for HTTP DELETE requests to the route.

--- a/docs/reference/csharp/v0/api/api-route-get.md
+++ b/docs/reference/csharp/v0/api/api-route-get.md
@@ -1,6 +1,6 @@
 ---
-title: api.route.get()
-description: Register a handler for HTTP GET requests to the route.
+title: .NET - api.route.get()
+description: Reference for Nitric's .NET library - Register a handler for HTTP GET requests to the route.
 ---
 
 Register a handler for HTTP GET requests to the route.

--- a/docs/reference/csharp/v0/api/api-route-patch.md
+++ b/docs/reference/csharp/v0/api/api-route-patch.md
@@ -1,6 +1,6 @@
 ---
-title: api.route.patch()
-description: Register a handler for HTTP PATCH requests to the route.
+title: .NET - api.route.patch()
+description: Reference for Nitric's .NET library - Register a handler for HTTP PATCH requests to the route.
 ---
 
 Register a handler for HTTP PATCH requests to the route.

--- a/docs/reference/csharp/v0/api/api-route-post.md
+++ b/docs/reference/csharp/v0/api/api-route-post.md
@@ -1,6 +1,6 @@
 ---
-title: api.route.post()
-description: Register a handler for HTTP POST requests to the route.
+title: .NET - api.route.post()
+description: Reference for Nitric's .NET library - Register a handler for HTTP POST requests to the route.
 ---
 
 Register a handler for HTTP POST requests to the route.

--- a/docs/reference/csharp/v0/api/api-route-put.md
+++ b/docs/reference/csharp/v0/api/api-route-put.md
@@ -1,6 +1,6 @@
 ---
-title: api.route.put()
-description: Register a handler for HTTP PUT requests to the route.
+title: .NET - api.route.put()
+description: Reference for Nitric's .NET library - Register a handler for HTTP PUT requests to the route.
 ---
 
 Register a handler for HTTP PUT requests to the route.

--- a/docs/reference/csharp/v0/api/api-route.md
+++ b/docs/reference/csharp/v0/api/api-route.md
@@ -1,6 +1,6 @@
 ---
-title: api.route()
-description: Creates a new route (path) within an API.
+title: .NET - api.route()
+description: Reference for Nitric's .NET library - Creates a new route (path) within an API.
 ---
 
 Creates a new route (path) within an API.

--- a/docs/reference/csharp/v0/api/api.md
+++ b/docs/reference/csharp/v0/api/api.md
@@ -1,6 +1,6 @@
 ---
-title: api()
-description: Create APIs with the Nitric C# SDK
+title: .NET - api()
+description: Reference for Nitric's .NET library - Create APIs with the Nitric C# SDK
 ---
 
 Creates a new HTTP API.

--- a/docs/reference/csharp/v0/index.md
+++ b/docs/reference/csharp/v0/index.md
@@ -1,6 +1,6 @@
 ---
-title: Nitric's .NET SDK
-description: Using Nitric with C# and .NET
+title: .NET - Nitric's .NET SDK
+description: Reference for Nitric's .NET library - Using Nitric with C# and .NET
 ---
 
 This SDK reference provides documentation for the functions and methods in Nitric's .NET library for C# and .NET.

--- a/docs/reference/csharp/v0/queues/queue-receive.md
+++ b/docs/reference/csharp/v0/queues/queue-receive.md
@@ -1,6 +1,6 @@
 ---
-title: queue.receive()
-description: Receive tasks from a queue.
+title: .NET - queue.receive()
+description: Reference for Nitric's .NET library - Receive tasks from a queue.
 ---
 
 Receive tasks from a queue.

--- a/docs/reference/csharp/v0/queues/queue-send.md
+++ b/docs/reference/csharp/v0/queues/queue-send.md
@@ -1,6 +1,6 @@
 ---
-title: queue.send()
-description: Send tasks to a queue.
+title: .NET - queue.send()
+description: Reference for Nitric's .NET library - Send tasks to a queue.
 ---
 
 Send tasks to a queue.

--- a/docs/reference/csharp/v0/queues/queue.md
+++ b/docs/reference/csharp/v0/queues/queue.md
@@ -1,6 +1,6 @@
 ---
-title: queue()
-description: Creates a new Queue to send and receive asynchronous tasks.
+title: .NET - queue()
+description: Reference for Nitric's .NET library - Creates a new Queue to send and receive asynchronous tasks.
 ---
 
 Creates a new Queue to send and receive asynchronous tasks.

--- a/docs/reference/csharp/v0/schedule/schedule-every.md
+++ b/docs/reference/csharp/v0/schedule/schedule-every.md
@@ -1,6 +1,6 @@
 ---
-title: schedule.every()
-description: Sets the frequency and one or many handlers to be triggered.
+title: .NET - schedule.every()
+description: Reference for Nitric's .NET library - Sets the frequency and one or many handlers to be triggered.
 ---
 
 Sets the frequency and one or many handlers to be triggered.

--- a/docs/reference/csharp/v0/schedule/schedule.md
+++ b/docs/reference/csharp/v0/schedule/schedule.md
@@ -1,6 +1,6 @@
 ---
-title: schedule()
-description: Creates a new Schedule to run a function on a defined frequency.
+title: .NET - schedule()
+description: Reference for Nitric's .NET library - Creates a new Schedule to run a function on a defined frequency.
 ---
 
 Creates a new Schedule to run a function on a defined frequency.

--- a/docs/reference/csharp/v0/storage/bucket-file-delete.md
+++ b/docs/reference/csharp/v0/storage/bucket-file-delete.md
@@ -1,6 +1,6 @@
 ---
-title: bucket.file.delete()
-description: Delete a file from a bucket.
+title: .NET - bucket.file.delete()
+description: Reference for Nitric's .NET library - Delete a file from a bucket.
 ---
 
 Delete a file from a bucket.

--- a/docs/reference/csharp/v0/storage/bucket-file-downloadurl.md
+++ b/docs/reference/csharp/v0/storage/bucket-file-downloadurl.md
@@ -1,6 +1,6 @@
 ---
-title: bucket.file.getDownloadUrl()
-description: Get a download url for a file from a bucket.
+title: .NET - bucket.file.getDownloadUrl()
+description: Reference for Nitric's .NET library - Get a download url for a file from a bucket.
 ---
 
 Create a download url for a file within a bucket.

--- a/docs/reference/csharp/v0/storage/bucket-file-read.md
+++ b/docs/reference/csharp/v0/storage/bucket-file-read.md
@@ -1,6 +1,6 @@
 ---
-title: bucket.file.read()
-description: Read the contents of a file from a bucket.
+title: .NET - bucket.file.read()
+description: Reference for Nitric's .NET library - Read the contents of a file from a bucket.
 ---
 
 Read the contents of a file from a bucket.

--- a/docs/reference/csharp/v0/storage/bucket-file-uploadurl.md
+++ b/docs/reference/csharp/v0/storage/bucket-file-uploadurl.md
@@ -1,6 +1,6 @@
 ---
-title: bucket.file.geUploadUrl()
-description: Get a upload url for a file from a bucket.
+title: .NET - bucket.file.geUploadUrl()
+description: Reference for Nitric's .NET library - Get a upload url for a file from a bucket.
 ---
 
 Create a upload url for a file within a bucket.

--- a/docs/reference/csharp/v0/storage/bucket-file-write.md
+++ b/docs/reference/csharp/v0/storage/bucket-file-write.md
@@ -1,6 +1,6 @@
 ---
-title: bucket.file.write()
-description: Write a file to a bucket.
+title: .NET - bucket.file.write()
+description: Reference for Nitric's .NET library - Write a file to a bucket.
 ---
 
 Write a file to a bucket.

--- a/docs/reference/csharp/v0/storage/bucket-file.md
+++ b/docs/reference/csharp/v0/storage/bucket-file.md
@@ -1,6 +1,6 @@
 ---
-title: bucket.file()
-description: Create a reference to a file within a bucket.
+title: .NET - bucket.file()
+description: Reference for Nitric's .NET library - Create a reference to a file within a bucket.
 ---
 
 Create a reference to a file within a bucket.

--- a/docs/reference/csharp/v0/storage/bucket-files.md
+++ b/docs/reference/csharp/v0/storage/bucket-files.md
@@ -1,6 +1,6 @@
 ---
-title: bucket.files()
-description: Get a list of file references for files that exist in the bucket.
+title: .NET - bucket.files()
+description: Reference for Nitric's .NET library - Get a list of file references for files that exist in the bucket.
 ---
 
 Get a list of file references for files that exist in the bucket.

--- a/docs/reference/csharp/v0/storage/bucket-on.md
+++ b/docs/reference/csharp/v0/storage/bucket-on.md
@@ -1,0 +1,77 @@
+---
+title: .NET - bucket.on()
+description: Reference for Nitric's .NET library - Create a new bucket notification trigger
+---
+
+Create a new bucket notification trigger when certain files are created or deleted.
+
+```csharp
+using System;
+using Nitric.Sdk;
+using Nitric.Sdk.Resource;
+using Nitric.Sdk.Storage;
+using BucketNotificationType = Nitric.Sdk.Function.BucketNotificationType;
+
+var assets = Nitric.Bucket("assets");
+
+var accessibleAssets = Nitric.Bucket("assets").With(BucketPermission.Reading);
+
+// The request will contain the name of the file `Key` and the type of event `NotificationType`
+assets.On(BucketNotificationType.Delete, "*", context => {
+  Console.WriteLine("A file named " + context.Req.Key + "was deleted");
+
+  return context;
+});
+
+assets.On(BucketNotificationType.Write, "/images/cat", context => {
+  Console.WriteLine("A cat image was written");
+
+  return context;
+});
+
+// If `.On()` is called with a permissioned bucket, a file reference will also be provided with the request
+accessibleAssets.On(BucketNotificationType.Write, "/images/dog", context => {
+  var dogImage = context.Req.File.Read();
+
+  Console.WriteLine(dogImage.ToString());
+
+  return context;
+});
+
+Nitric.Run();
+```
+
+## Parameters
+
+---
+
+**notification type** required `BucketNotificationType.Write` or `BucketNotificationType.Delete`
+
+The notification type for a triggered event, either on a file write or a file delete.
+
+**notification prefix filter** required `string`
+
+The file prefix filter that must match for a triggered event. If multiple filters overlap across notifications then an error will be thrown when registering the resource.
+
+**middleware** required `BucketNotificationMiddleware` or `BucketNotificationMiddleware[]`
+
+The middleware (code) to be triggered by the bucket notification being triggered.
+
+---
+
+### Available trigger types:
+
+**BucketNotificationType.Write**
+
+Run when a file in the bucket is created using: `file.Write()`
+
+**BucketNotificationType.Delete**
+
+Run when a file in the bucket is deleted using: `file.Delete()`
+
+### Trigger type cloud mapping
+
+| Permission                    | AWS                 | GCP             | Azure                         |
+| ----------------------------- | ------------------- | --------------- | ----------------------------- |
+| BucketNotificationType.Write  | s3:ObjectCreated:\* | OBJECT_FINALIZE | Microsoft.Storage.BlobCreated |
+| BucketNotificationType.Delete | s3:ObjectRemoved:\* | OBJECT_DELETE   | Microsoft.Storage.BlobDeleted |

--- a/docs/reference/csharp/v0/storage/bucket.md
+++ b/docs/reference/csharp/v0/storage/bucket.md
@@ -1,6 +1,6 @@
 ---
-title: bucket()
-description: Create a new bucket for storing and retrieving files.
+title: .NET - bucket()
+description: Reference for Nitric's .NET library - Create a new bucket for storing and retrieving files.
 ---
 
 Create a new bucket for storing and retrieving files.

--- a/docs/reference/csharp/v0/topic/topic-publish.md
+++ b/docs/reference/csharp/v0/topic/topic-publish.md
@@ -1,6 +1,6 @@
 ---
-title: topic.publish()
-description: Publish new events to the topic.
+title: .NET - topic.publish()
+description: Reference for Nitric's .NET library - Publish new events to the topic.
 ---
 
 Publish an event (push based message) to a topic.

--- a/docs/reference/csharp/v0/topic/topic-subscribe.md
+++ b/docs/reference/csharp/v0/topic/topic-subscribe.md
@@ -1,6 +1,6 @@
 ---
-title: topic.subscribe()
-description: Subscribe a handler to a topic and receive new events for processing.
+title: .NET - topic.subscribe()
+description: Reference for Nitric's .NET library - Subscribe a handler to a topic and receive new events for processing.
 ---
 
 Subscribe a handler to a topic and receive new events for processing.

--- a/docs/reference/csharp/v0/topic/topic.md
+++ b/docs/reference/csharp/v0/topic/topic.md
@@ -1,6 +1,6 @@
 ---
-title: topic()
-description: Creates a new Topic.
+title: .NET - topic()
+description: Reference for Nitric's .NET library - Creates a new Topic.
 ---
 
 Creates a new Topic.


### PR DESCRIPTION
Added prefixes to title and descriptions of .NET documentation to be consistent with Node and Python references. Also added the bucket notification documentation

Relies on https://github.com/nitrictech/dotnet-sdk/pull/57