### PR TITLE
docs(python): updates to  match upcoming SDK changes

### DIFF
--- a/src/pages/guides/getting-started/nodejs/stripe.mdx
+++ b/src/pages/guides/getting-started/nodejs/stripe.mdx
@@ -22,7 +22,7 @@ Creating a Stripe checkout backed by a Nitric API and collections. This API will
 
 ## Getting started
 
-We’ll start by creating a new project for our API.
+We'll start by creating a new project for our API.
 
 ```bash
 nitric new

--- a/src/pages/guides/getting-started/python/create-histogram.mdx
+++ b/src/pages/guides/getting-started/python/create-histogram.mdx
@@ -15,7 +15,7 @@ We'll be making a serverless application which can take information from a HTTP 
 
 ## Getting started
 
-We’ll start by creating a new project for our API.
+We'll start by creating a new project for our API.
 
 ```bash
 nitric new
@@ -45,10 +45,13 @@ Starting from scratch in the `hello.py` function file, lets start by importing a
 ```python
 from nitric.resources import api
 from nitric.application import Nitric
+from nitric.faas import HttpContext
 
-mainApi = api("main")
+
+main_api = api("main")
 
 Nitric.run()
+
 ```
 
 We can then define our api route which will accept the histogram data to then be returned as an image.
@@ -56,15 +59,18 @@ We can then define our api route which will accept the histogram data to then be
 ```python
 from nitric.resources import api
 from nitric.application import Nitric
+from nitric.faas import HttpContext
 import matplotlib as plt
 
-mainApi = api("main")
 
-@mainApi.get("/histogram")
-async def create_histogram(ctx):
+main_api = api("main")
+
+@main_api.get("/histogram")
+async def create_histogram(ctx: HttpContext) -> None:
   pass
 
 Nitric.run()
+
 ```
 
 The route will be registered for a GET method so that it is a link that can be embed. For example, once the api is complete, it will be able to be used in situations like:
@@ -78,8 +84,8 @@ The route will be registered for a GET method so that it is a link that can be e
 We can then write the logic for creating the histogram from the request. As seen in the above url, there are 4 query parameters that we want a user to be able to configure, the data, y-label, x-label, and title.
 
 ```python
-@mainApi.get("/histogram")
-async def create_histogram(ctx):
+@main_api.get("/histogram")
+async def create_histogram(ctx: HttpContext) -> None
   # Extract the comma-delimited data and split it into array
   data = ctx.req.query.get("data")[0].split(',')
 

--- a/src/pages/guides/getting-started/python/graphql.mdx
+++ b/src/pages/guides/getting-started/python/graphql.mdx
@@ -234,7 +234,7 @@ Then add the api handler.
 
 ```python
 @graph_api.post("/")
-async def profile_handler(ctx):
+async def profile_handler(ctx: HttpContext) -> None:
     query = ctx.req.json
 
     success, result = await graphql(

--- a/src/pages/guides/getting-started/python/serverless-rest-api-example.mdx
+++ b/src/pages/guides/getting-started/python/serverless-rest-api-example.mdx
@@ -102,6 +102,7 @@ from uuid import uuid4
 
 from nitric.resources import api, collection, bucket
 from nitric.application import Nitric
+from nitric.faas import HttpContext
 
 # Create an api named public
 profile_api = api("public")
@@ -123,7 +124,7 @@ From here, let's add some features to that function that allow us to work with p
 
 ```python
 @profile_api.post("/profiles")
-async def create_profile(ctx):
+async def create_profile(ctx: HttpContext) -> None:
   pid = str(uuid4())
   name = ctx.req.json['name']
   age = ctx.req.json['age']
@@ -138,7 +139,7 @@ async def create_profile(ctx):
 
 ```python
 @profile_api.get("/profiles/:id")
-async def get_profile(ctx):
+async def get_profile(ctx: HttpContext) -> None:
   pid = ctx.req.params['id']
   d = await profiles.doc(pid).get()
 
@@ -150,7 +151,7 @@ async def get_profile(ctx):
 
 ```python
 @profile_api.get("/profiles")
-async def get_profiles(ctx):
+async def get_profiles(ctx: HttpContext) -> None:
   results = await profiles.query().fetch()
   r = [doc.content for doc in results.documents]
   ctx.res.body = f"{r}"
@@ -160,7 +161,7 @@ async def get_profiles(ctx):
 
 ```python
 @profile_api.delete("/profiles/:id")
-async def delete_profiles(ctx):
+async def delete_profiles(ctx: HttpContext) -> None:
   pid = ctx.req.params['id']
 
   try:
@@ -170,7 +171,9 @@ async def delete_profiles(ctx):
     ctx.res.status = 404
     ctx.res.body = { 'msg': f'Profile with id {pid} not found.'}
 
+
 Nitric.run()
+
 ```
 
 ## Ok, let's run this thing!
@@ -291,7 +294,7 @@ from datetime import datetime, timedelta
 
 ```python
 @profile_api.get("/profiles/:id/image/upload")
-async def upload_profile_image(ctx):
+async def upload_profile_image(ctx: HttpContext) -> None:
 
   pid = ctx.req.params['id']
 
@@ -309,7 +312,7 @@ async def upload_profile_image(ctx):
 
 ```python
 @profile_api.get("/profiles/:id/image/view")
-async def download_profile_image(ctx):
+async def download_profile_image(ctx: HttpContext) -> None:
   pid = ctx.req.params['id']
 
   photo =  photos.file(f'images/{pid}/photo.png')
@@ -326,7 +329,7 @@ You can also directly redirect to the photo URL.
 
 ```python
 @profile_api.get("/profiles/:id/image/view")
-async def download_profile_image(ctx):
+async def download_profile_image(ctx: HttpContext) -> None:
   pid = ctx.req.params['id']
 
   photo =  photos.file(f'images/{pid}/photo.png')

--- a/src/pages/guides/getting-started/python/text-prediction.mdx
+++ b/src/pages/guides/getting-started/python/text-prediction.mdx
@@ -138,7 +138,7 @@ data = convert_numbers(data)
 
 # Save the cleaned data in a new file
 with open('clean_data.txt', 'w') as f:
-    f.write(data)
+  f.write(data)
 ```
 
 Before we are done, we will want to tokenize the data so that it can be processed by the model. After it's fit to the text, we will save it so we can use it later. To tokenize the data, we will use keras' pre-processing module. For this we require the keras module.
@@ -159,7 +159,7 @@ tokenizer.fit_on_texts(data.split())
 
 # Save tokenizer
 with open('tokenizer.pickle', 'wb') as handle:
-    pickle.dump(tokenizer, handle, protocol=pickle.HIGHEST_PROTOCOL)
+  pickle.dump(tokenizer, handle, protocol=pickle.HIGHEST_PROTOCOL)
 ```
 
 ## Training the model
@@ -172,7 +172,7 @@ Start by loading the tokenizer from the pre-processing stage.
 import pickle
 
 with open('tokenizer.pickle', 'rb') as handle:
-    tokenizer = pickle.load(handle)
+  tokenizer = pickle.load(handle)
 ```
 
 We can then create all the input sequences to train our model. This works by getting every 6 word combination in the text. First add numpy as a dependency.
@@ -194,8 +194,8 @@ def create_input_sequences(data: list[str], n_gram_size=6):
 
   # Sliding iteration which takes every 6 words in a row as an input sequence
   for i in range(1, len(token_list) - n_gram_size):
-      n_gram_sequence = token_list[i:i+n_gram_size]
-      input_sequences.append(n_gram_sequence)
+    n_gram_sequence = token_list[i:i+n_gram_size]
+    input_sequences.append(n_gram_sequence)
 
   # Pad sequences
   max_sequence_len = max([len(x) for x in input_sequences])
@@ -305,20 +305,20 @@ model = None
 tokenizer = None
 
 def load_tokenizer():
-    global tokenizer
-    if tokenizer is None:
-        # Load the tokenizer
-        with open('prediction/tokenizer.pickle', 'rb') as handle:
-            tokenizer = pickle.load(handle)
-    return tokenizer
+  global tokenizer
+  if tokenizer is None:
+    # Load the tokenizer
+    with open('prediction/tokenizer.pickle', 'rb') as handle:
+      tokenizer = pickle.load(handle)
+  return tokenizer
 
 def load_model():
-    global model
-    if model is None:
-        models = importlib.import_module("keras.models")
-        # Load the model
-        model = models.load_model('prediction/model.h5')
-    return model
+  global model
+  if model is None:
+    models = importlib.import_module("keras.models")
+    # Load the model
+    model = models.load_model('prediction/model.h5')
+  return model
 ```
 
 Once the model is loaded, we can write a function to predict the next 3 most likely words. This uses the tokenizer to create the same token list that was used to train the model. We can then get a prediction of all the most likely words, which we will reduce down to 3. We'll then get the actual word from the map of tokens by finding the word in the dictionary. The tokenizer word index is in the from `{ "word": token_num }`, e.g. `{ "the": 1, "and": 2 }`. The predictions we receive will be an array of the token numbers.
@@ -327,34 +327,34 @@ Once the model is loaded, we can write a function to predict the next 3 most lik
 # Predict text based on a set of seed text
 # Returns a list of 3 top choices for the next word
 def predict_text(seed_text: str) -> list[str]:
-    # Dynamically load the utils
-    utils = importlib.import_module("keras.utils")
+  # Dynamically load the utils
+  utils = importlib.import_module("keras.utils")
 
-    # Convert the seed text into a token list using the same process as the previous tokenization
-    token_list = load_tokenizer().texts_to_sequences([seed_text])[0]
-    token_list = utils.pad_sequences([token_list], maxlen=5, padding='pre')
+  # Convert the seed text into a token list using the same process as the previous tokenization
+  token_list = load_tokenizer().texts_to_sequences([seed_text])[0]
+  token_list = utils.pad_sequences([token_list], maxlen=5, padding='pre')
 
-    # Make the prediction
-    m  = load_model()
+  # Make the prediction
+  m  = load_model()
 
-    predict_x = m.predict(token_list, batch_size=500, verbose=0)
+  predict_x = m.predict(token_list, batch_size=500, verbose=0)
 
-    # Find the top three words
-    predict_x = np.argpartition(predict_x, -3, axis=1)[0][-3:]
+  # Find the top three words
+  predict_x = np.argpartition(predict_x, -3, axis=1)[0][-3:]
 
-    # Reverse the list so the most popular is first
-    predictions = list(predict_x)
-    predictions.reverse()
+  # Reverse the list so the most popular is first
+  predictions = list(predict_x)
+  predictions.reverse()
 
-    # Iterate over the predicted words, and find the word in the tokenizer dictionary that matches
-    output_words = []
-    for prediction in predictions:
-        for word, index in tokenizer.word_index.items():
-            if prediction == index:
-                output_words.append(word)
-                break
+  # Iterate over the predicted words, and find the word in the tokenizer dictionary that matches
+  output_words = []
+  for prediction in predictions:
+    for word, index in tokenizer.word_index.items():
+      if prediction == index:
+        output_words.append(word)
+        break
 
-    return output_words
+  return output_words
 ```
 
 ## Creating the API
@@ -364,6 +364,7 @@ Using the predictive text function, we can create our API. First we will make su
 ```python
 from nitric.resources import api
 from nitric.application import Nitric
+from nitric.faas import HttpContext
 ```
 
 We will then define the API and our first route.
@@ -372,8 +373,8 @@ We will then define the API and our first route.
 mainApi = api("main")
 
 @mainApi.get("/prediction")
-async def create_prediction(ctx):
-    pass
+async def create_prediction(ctx: HttpContext) -> None:
+  pass
 
 Nitric.run()
 ```
@@ -382,13 +383,13 @@ Within this function block we want to define the code that is run on a request. 
 
 ```python
 @mainApi.get("/prediction")
-async def create_prediction(ctx):
-    prompt = ctx.req.query.get("prompt")
+async def create_prediction(ctx: HttpContext) -> None:
+  prompt = ctx.req.query.get("prompt")
 
-    if prompt is None:
-      return
+  if prompt is None:
+    return
 
-    prompt = " ".join(prompt)
+  prompt = " ".join(prompt)
 
 Nitric.run()
 ```
@@ -397,14 +398,14 @@ With the users prompt we can then do the prediction and return to the user the p
 
 ```python
 @mainApi.get("/prediction")
-async def create_prediction(ctx):
-    ...
+async def create_prediction(ctx: HttpContext) -> None:
+  ...
 
-    prompt = " ".join(prompt)
+  prompt = " ".join(prompt)
 
-    prediction = predict_text(prompt)
+  prediction = predict_text(prompt)
 
-    ctx.res.body = f"{prompt} {prediction}"
+  ctx.res.body = f"{prompt} {prediction}"
 
 Nitric.run()
 ```

--- a/src/pages/reference/python/v0/storage/bucket-on.mdx
+++ b/src/pages/reference/python/v0/storage/bucket-on.mdx
@@ -14,11 +14,11 @@ accessible_assets = bucket("assets").allow("reading")
 
 # The request will contain the name of the file `key` and the type of event `type`
 @assets.on("delete", "*")
-def delete_anything(ctx):
+async def delete_anything(ctx):
   print(f"a file named {ctx.req.key} was deleted")
 
 @assets.on("write", "/images/cat")
-def create_cat_image(ctx):
+async def create_cat_image(ctx):
   print(f"A cat image was written")
 
 # If `on` is called with a permissioned bucket, a file will also be provided with the request

--- a/src/pages/storage.mdx
+++ b/src/pages/storage.mdx
@@ -248,7 +248,7 @@ profiles = bucket("profiles")
 
 # Filter for 'write' events for files starting with '/users/images'
 @profiles.on("write", "/users/images")
-def image_written(ctx):
+async def image_written(ctx):
 	print(f"new profile image for {ctx.req.key} was written")
 ```
 
@@ -276,7 +276,7 @@ profiles = bucket("profiles")
 
 # Filter for 'delete' events for any file
 @profiles.on("delete", "*")
-def file_deleted(ctx):
+async def file_deleted(ctx):
 	print(f"{ctx.req.key} was deleted")
 ```
 


### PR DESCRIPTION
Only use `async` for handler definitions. This change is compatible with the current SDK version and represents the restrictions of the upcoming version which removes support for non-async handlers.