### PR TITLE
add prefix when enter key is used on docs hit

### DIFF
--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -10,7 +10,7 @@ const docSearchConfig = {
 }
 
 function Hit({ hit, children }) {
-  return <Link href={hit.url}>{children}</Link>
+  return <Link href={`/docs${hit.url}`}>{children}</Link>
 }
 
 function SearchIcon(props) {

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import Link from 'next/link'
 import { DocSearchModal, useDocSearchKeyboardEvents } from '@docsearch/react'
+import { useRouter } from 'next/router'
 
 const docSearchConfig = {
   appId: process.env.NEXT_PUBLIC_DOCSEARCH_APP_ID || '',
@@ -10,7 +11,21 @@ const docSearchConfig = {
 }
 
 function Hit({ hit, children }) {
-  return <Link href={`/docs${hit.url}`}>{children}</Link>
+  const router = useRouter()
+
+  return (
+    <Link
+      onKeyDown={(evt) => {
+        evt.preventDefault()
+        if (evt.code === '13') {
+          router.push(hit.url)
+        }
+      }}
+      href={hit.url}
+    >
+      {children}
+    </Link>
+  )
 }
 
 function SearchIcon(props) {


### PR DESCRIPTION
When the enter key is pressed on a highlighted docs hit, the /docs prefix is not added. This results in the search going to the 404 page. This behaviour was fixed when clicking on the link but not when the enter key is pressed.