### PR TITLE
add cors section to apis

### DIFF
--- a/src/pages/apis.mdx
+++ b/src/pages/apis.mdx
@@ -1469,3 +1469,163 @@ fun main() {
 ```
 
 </CodeGroup>
+
+## Handling CORS
+
+To enable [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) (Cross-Origin Resource Sharing), you can use the `cors` option to define CORS policies for all API routes. If you need to configure CORS for a specific route manually, you can use a middleware function.
+
+By default, CORS is disabled. To enable it, set the `cors` option to `true`, which will allow all HTTP methods and headers from any origin. You also have the flexibility to customize these default options as needed.
+
+<CodeGroup>
+
+```javascript {{ tag: 'resources/index.js' }}
+import { api } from '@nitric/sdk'
+
+// enable cors with defaults
+export const mainApi = api('main', {
+  cors: true,
+})
+
+// enable cors and override defaults
+export const secondApi = api('second', {
+  cors: {
+    allowOrigins: ['https://www.domain.com'],
+    allowHeaders: ['Authorization'],
+  },
+})
+```
+
+```python {{ tag: 'common/resources.py' }}
+# global support is being added to the SDK soon. In the meantime you can do it manually by using middleware and adding options routes.
+from nitric.application import Nitric
+from nitric.resources import api, ApiOptions
+from nitric.faas import HttpContext, HttpMiddleware
+
+def cors(ctx: HttpContext, next: HttpMiddleware):
+  # Allow all Origins
+  ctx.res.headers["Access-Control-Allow-Origin"] = ["*"]
+
+  # Local dev only (i.e. localhost)
+  ctx.res.headers["Access-Control-Allow-Origin"] = ["http://localhost:4001"]
+
+  ctx.res.headers["Access-Control-Allow-Methods"] = [
+    "GET, POST, PATCH, DELETE, OPTIONS"
+  ]
+
+  access_control = ctx.res.headers["Access-Control-Request-Headers"]
+  if access_control is not None:
+    if not isinstance(access_control, list):
+      access_control = [access_control]
+    ctx.res.headers["Access-Control-Allow-Headers"] = access_control
+
+  return next(ctx)
+
+mainApi = api("main", ApiOptions(middleware = [cors]))
+```
+
+```go {{ tag: 'resources.go' }}
+// global support is being added to the SDK soon. In the meantime you can do it manually by using middleware and adding options routes.
+package main
+
+import (
+	"github.com/nitrictech/go-sdk/faas"
+	"github.com/nitrictech/go-sdk/nitric"
+)
+
+func cors(ctx *faas.HttpContext, next faas.HttpHandler) (*faas.HttpContext, error) {
+	headers := ctx.Request.Headers()
+
+	// Allow all Origins
+	ctx.Response.Headers["Access-Control-Allow-Origin"] = []string{"*"}
+
+	// Local dev only (i.e. localhost)
+	ctx.Response.Headers["Access-Control-Allow-Origin"] = []string{"http://localhost:4001"}
+
+	ctx.Response.Headers["Access-Control-Allow-Methods"] = []string{"GET, POST, PATCH, DELETE, OPTIONS"}
+
+	if headers["Access-Control-Request-Headers"] != nil {
+		ctx.Response.Headers["Access-Control-Allow-Methods"] = headers["Access-Control-Request-Headers"]
+	}
+
+	return next(ctx)
+}
+
+
+func NewMainApi() (nitric.Api, error) {
+	mainApi, err := nitric.NewApi("main",  nitric.WithMiddleware(cors))
+	if err != nil {
+		return nil, nil
+	}
+
+	return mainApi, nil
+}
+```
+
+```java {{ tag: 'Resources.java' }}
+// global support is being added to the SDK soon. In the meantime you can do it manually by using middleware and adding options routes.
+package org.example;
+
+import io.nitric.Nitric;
+import io.nitric.faas.v0.Handler;
+import io.nitric.faas.v0.HttpContext;
+import io.nitric.resources.ApiOptions;
+import io.nitric.resources.ApiResource;
+import java.util.List;
+
+public class Apis {
+  static HttpContext cors(HttpContext ctx, Handler<HttpContext> next) {
+    // Allow all origins
+    ctx.getResp().getHeaders().put("Access-Control-Allow-Origin", List.of("*"));
+
+    // Local dev only (i.e. localhost)
+    ctx.getResp().getHeaders().put("Access-Control-Allow-Origin", List.of("http://localhost:4001"));
+
+    ctx.getResp().getHeaders().put("Access-Control-Allow-Methods", List.of("GET, POST, PATCH, DELETE, OPTIONS"));
+
+    var accessControl = ctx.getResp().getHeaders().get("Access-Control-Request-Headers");
+    if (accessControl != null) {
+      ctx.getResp().getHeaders().put("Access-Control-Allow-Headers", accessControl);
+    }
+
+    return next.invoke(ctx);
+  }
+
+  public static ApiResource mainApi() {
+    return Nitric.INSTANCE.api("main",
+      new ApiOptions.Builder().middleware(Apis::cors).build()
+    );
+  }
+}
+```
+
+```kotlin
+// global support is being added to the SDK soon. In the meantime you can do it manually by using middleware and adding options routes.
+import io.nitric.faas.v0.HttpContext
+import io.nitric.Nitric
+import io.nitric.faas.v0.Middleware
+import io.nitric.resources.ApiOptions
+import io.nitric.resources.ApiResource
+
+val cors = Middleware<HttpContext> { ctx, next ->
+  // Allow all origins
+  ctx.resp.headers["Access-Control-Allow-Origin"] = listOf("*");
+
+  // Local dev only (i.e. localhost)
+  ctx.resp.headers["Access-Control-Allow-Origin"] = listOf("http://localhost:4001");
+
+  ctx.resp.headers["Access-Control-Allow-Methods"] = listOf("GET, POST, PATCH, DELETE, OPTIONS");
+
+  val accessControl = ctx.resp.headers["Access-Control-Request-Headers"];
+  if (accessControl != null) {
+    ctx.resp.headers["Access-Control-Allow-Headers"] = accessControl;
+  }
+
+  return@Middleware next(ctx)
+}
+
+fun mainApi(): ApiResource {
+  return Nitric.api("main", ApiOptions(middleware = listOf(cors)))
+}
+```
+
+</CodeGroup>

--- a/src/pages/reference/nodejs/v0/api/api.mdx
+++ b/src/pages/reference/nodejs/v0/api/api.mdx
@@ -37,6 +37,10 @@ const publicApi = api('public')
         Security rules to apply with scopes to the entire API. Keys must match a
         **securityDefinition**.
       </Property>
+      <Property name="cors" type="boolean or CorsOptions">
+        CORS support applied to all endpoints in this API. Keys must match
+        **CorsOptions**. Defaults to false.
+      </Property>
     </Properties>
   </Property>
 </Properties>
@@ -56,9 +60,85 @@ const publicApi = api('public')
   </Property>
 </Properties>
 
+### CorsOptions Parameters
+
+Below are the CORS properties you can override and their defaults. Learn more about <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS" target="_blank">CORS</a>.
+
+<Properties>
+  <Property name="allowCredentials" type="boolean">
+    Specifies whether credentials are included in the CORS request. Defaults to false.
+  </Property>
+  <Property name="allowHeaders" type="string[]">
+    The collection of allowed headers. Defaults to allow all headers.
+
+    <CodeGroup>
+
+```javascript
+// Allow all headers
+allowHeaders: ['*']
+
+// Allow specific headers
+allowHeaders: ['Accept', 'Content-Type', 'Authorization']
+```
+
+</CodeGroup>
+
+  </Property>
+  <Property
+    name="allowMethods"
+    type="('GET' | 'PUT' | 'POST' | 'DELETE' | 'PATCH' | 'OPTIONS')[]"
+  >
+    The collection of allowed HTTP methods. Defaults to allow all methods.
+
+<CodeGroup>
+
+```javascript
+// Allow specific methods
+allowMethods: ['GET', 'POST']
+```
+
+</CodeGroup>
+
+  </Property>
+  <Property name="allowOrigins" type="string[]">
+    The collection of allowed origins. Defaults to allow all origins.
+
+<CodeGroup>
+
+```javascript
+// Allow all origins
+allowOrigins: ['*']
+
+// Allow specific origins. Note that the url protocol, ie. "https://", is required.
+allowOrigins: ['https://domain.com']
+```
+
+</CodeGroup>
+
+  </Property>
+  <Property name="exposeHeaders" type="string[]">
+    The collection of exposed headers. Defaults to no expose headers are allowed.
+  </Property>
+  <Property
+    name="maxAge"
+    type="${number} second | ${number} seconds | ${number} minute | ${number} minutes | ${number} hour | ${number} hours | ${number} day | ${number} days"
+  >
+    Specify how long the results of a preflight response can be cached. Defaults to no caching.
+
+<CodeGroup>
+
+```javascript
+maxAge: '1 day'
+```
+
+</CodeGroup>
+
+  </Property>
+</Properties>
+
 ### Notes
 
-The `middleware` property on the `options` param is useful for applying universal middleware such as CORS headers or Auth, across an entire API from a single place.
+The `middleware` property on the `options` param is useful for applying universal middleware such as Auth, across an entire API from a single place.
 
 ## Examples
 
@@ -68,6 +148,30 @@ The `middleware` property on the `options` param is useful for applying universa
 import { api } from '@nitric/sdk'
 
 const publicApi = api('public')
+```
+
+### Create an API with default CORS options
+
+```javascript
+import { api } from '@nitric/sdk'
+
+const publicApi = api('public', {
+  cors: true,
+})
+```
+
+### Create an API with overriding specific CORS options
+
+```javascript
+import { api } from '@nitric/sdk'
+
+const publicApi = api('public', {
+  cors: {
+    allowOrigins: ['https://foo.example'],
+    allowCredentials: true,
+    allowMethods: ['GET'],
+  },
+})
 ```
 
 ### Create an API with universal middleware


### PR DESCRIPTION
Adds cors section to APIs page and node reference.
Other languages will need SDKS updated first. The main APIs page shows how to enable cors via middleware for these.