### PR TITLE
Update keyvalue.mdx - fix typos with permissions

### DIFF
--- a/src/pages/reference/python/keyvalue/keyvalue.mdx
+++ b/src/pages/reference/python/keyvalue/keyvalue.mdx
@@ -31,19 +31,19 @@ All Nitric resources provide access permissions you can use to specify the level
 
 ---
 
-**getting**
+**get**
 
 This permission allows your service to get values from the key value store.
 
 ---
 
-**setting**
+**set**
 
 This permission allows your service to set key value pairs in the key value store.
 
 ---
 
-**deleting**
+**delete**
 
 This permission allows your service to delete key value pairs in the key value store.
 


### PR DESCRIPTION
Fixed typos with the description of available permissions for the Key-Value Store.