### PR TITLE
adjust install prerequisites

### DIFF
--- a/src/pages/getting-started/installation.mdx
+++ b/src/pages/getting-started/installation.mdx
@@ -14,7 +14,7 @@ Please follow these links to the official installation steps for each.
 - [Git](https://git-scm.com/)
 - [Docker](https://docs.docker.com/get-docker/) _(deployments only)_
 - [Docker Buildx](https://github.com/docker/buildx/) _(deployments only)_
-- [Pulumi](https://www.pulumi.com/docs/cli/) _(deployments only)_
+- [Pulumi](https://www.pulumi.com/docs/cli/) _(for deployments, only needed if using the default providers)_
 
 ## Installing the Nitric CLI
 

--- a/src/pages/reference/cli/installation.mdx
+++ b/src/pages/reference/cli/installation.mdx
@@ -9,9 +9,9 @@ Nitric relies on functionality from the following projects to help retrieve plug
 Please follow these links to the official installation steps for each.
 
 - [Git](https://git-scm.com/)
-- [Docker](https://docs.docker.com/get-docker/)
-- [Docker Buildx](https://github.com/docker/buildx/)
-- [Pulumi](https://www.pulumi.com/docs/cli/)
+- [Docker](https://docs.docker.com/get-docker/) _(deployments only)_
+- [Docker Buildx](https://github.com/docker/buildx/) _(deployments only)_
+- [Pulumi](https://www.pulumi.com/docs/cli/) _(for deployments, only needed if using the default providers)_
 
 ## Installing the Nitric CLI
 


### PR DESCRIPTION
Putting a note in to say pulumi is only required if using the default providers