### PR TITLE
doc: fix issue with python rest API guide

### DIFF
--- a/src/pages/guides/python/serverless-rest-api-example.mdx
+++ b/src/pages/guides/python/serverless-rest-api-example.mdx
@@ -124,7 +124,8 @@ async def get_profile(ctx: HttpContext) -> None:
   pid = ctx.req.params['id']
   d = await profiles.get(pid)
 
-  ctx.res.body = f"{d.content}"
+  ctx.res.body = f"{d}"
+  ctx.res.headers['Content-Type'] = 'application/json'
 ```
 
 ### Remove a profile with DELETE


### PR DESCRIPTION
Guide still referenced a v0 property on returned values
