### PR TITLE
Update aws cfg ephemeral templates for pulumi and terraform

### DIFF
--- a/docs/providers/pulumi/aws/configuration.mdx
+++ b/docs/providers/pulumi/aws/configuration.mdx
@@ -58,14 +58,18 @@ config:
     telemetry: 0
     # configure services to deploy to AWS lambda
     lambda: # Available since v0.26.0
-      # set 128MB of RAM
+      # set the memory in MB
       # See lambda configuration docs here:
       # https://docs.aws.amazon.com/lambda/latest/dg/configuration-function-common.html#configuration-memory-console
       memory: 128
-      # set a timeout of 15 seconds
+      # set a timeout in seconds
       # See lambda timeout values here:
       # https://docs.aws.amazon.com/lambda/latest/dg/configuration-function-common.html#configuration-timeout-console
       timeout: 15
+      # set the amount of ephemeral-storage in MB
+      # For info on ephemeral-storage for AWS Lambda see:
+      # https://docs.aws.amazon.com/lambda/latest/dg/configuration-ephemeral-storage.html
+      ephemeral-storage: 512
       # set a provisioned concurrency value
       # For info on provisioned concurrency for AWS Lambda see:
       # https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html
@@ -134,17 +138,18 @@ config:
     telemetry: 0
     # configure services to deploy to AWS lambda
     lambda: # Available since v0.26.0
-      # set 128MB of RAM
+      # set the memory in MB
       # See lambda configuration docs here:
       # https://docs.aws.amazon.com/lambda/latest/dg/configuration-function-common.html#configuration-memory-console
       memory: 128
-      # set a timeout of 15 seconds
+      # set a timeout in seconds
       # See lambda timeout values here:
       # https://docs.aws.amazon.com/lambda/latest/dg/configuration-function-common.html#configuration-timeout-console
       timeout: 15
-      # set a provisioned concurrency value
-      # For info on provisioned concurrency for AWS Lambda see:
-      # https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html
+      # set the amount of ephemeral-storage in MB
+      # For info on ephemeral-storage for AWS Lambda see:
+      # https://docs.aws.amazon.com/lambda/latest/dg/configuration-ephemeral-storage.html
+      ephemeral-storage: 512
   # Additional deployment types
   # You can target these types by setting a `type` in your project configuration
   big-service:

--- a/docs/providers/pulumi/aws/index.mdx
+++ b/docs/providers/pulumi/aws/index.mdx
@@ -105,11 +105,11 @@ config:
     telemetry: 0
     # configure services to deploy to AWS lambda
     lambda: # Available since v0.26.0
-      # set 128MB of RAM
+      # set the memory in MB
       # See lambda configuration docs here:
       # https://docs.aws.amazon.com/lambda/latest/dg/configuration-function-common.html#configuration-memory-console
       memory: 128
-      # set a timeout of 15 seconds
+      # set a timeout in seconds
       # See lambda timeout values here:
       # https://docs.aws.amazon.com/lambda/latest/dg/configuration-function-common.html#configuration-timeout-console
       timeout: 15

--- a/docs/providers/terraform/aws.mdx
+++ b/docs/providers/terraform/aws.mdx
@@ -111,17 +111,18 @@ config:
     telemetry: 0
     # configure services to deploy to AWS lambda
     lambda: # Available since v0.26.0
-      # set 128MB of RAM
+      # set the memory in MB
       # See lambda configuration docs here:
       # https://docs.aws.amazon.com/lambda/latest/dg/configuration-function-common.html#configuration-memory-console
       memory: 128
-      # set a timeout of 15 seconds
+      # set a timeout in seconds
       # See lambda timeout values here:
       # https://docs.aws.amazon.com/lambda/latest/dg/configuration-function-common.html#configuration-timeout-console
       timeout: 15
-      # set a provisioned concurrency value
-      # For info on provisioned concurrency for AWS Lambda see:
-      # https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html
+      # set the amount of ephemeral-storage in MB
+      # For info on ephemeral-storage for AWS Lambda see:
+      # https://docs.aws.amazon.com/lambda/latest/dg/configuration-ephemeral-storage.html
+      ephemeral-storage: 512
   # Additional deployment types
   # You can target these types by setting a `type` in your project configuration
   big-service:


### PR DESCRIPTION
```
# set the amount of ephemeral-storage: of 512MB
# For info on ephemeral-storage for AWS Lambda see:
# https://docs.aws.amazon.com/lambda/latest/dg/configuration-ephemeral-storage.html
ephemeral-storage: 512
```