### PR TITLE
docs: update python quickstart to use uv

### DIFF
--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -121,9 +121,9 @@ uv sync
 ```
 
 <Note>
-  We use `uv` by default in our base py-starter template. If you would prefer to use another dependency manager we also have a template for `pipenv`.
+We use `uv` by default in our base py-starter template. If you would prefer to use another dependency manager we also have a template for `pipenv`.
 
-If there are other dependency managers you would like to see supported, please let us know in our [github issues](github.com/nitrictech/nitric/issues).
+If there are other dependency managers you would like to see supported, please let us know in our [GitHub issues](https://github.com/nitrictech/nitric/issues).
 
 </Note>
 

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -117,14 +117,14 @@ npm install
 ```bash Python
 cd hello-world
 
-pipenv install --dev
+uv sync
 ```
 
 <Note>
-  We recommend using [Pipenv](https://pipenv.pypa.io/en/latest/) for dependency
-  management and virtual environments. It's included it in our python templates
-  by default. Installation instructions:
-  https://pipenv.pypa.io/en/latest/installation/#preferred-installation-of-pipenv
+  We use `uv` by default in our base py-starter template. If you would prefer to use another dependency manager we also have a template for `pipenv`.
+
+If there are other dependency managers you would like to see supported, please let us know in out [github issues](github.com/nitrictech/nitric/issues).
+
 </Note>
 
 </TabItem>

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -123,7 +123,7 @@ uv sync
 <Note>
   We use `uv` by default in our base py-starter template. If you would prefer to use another dependency manager we also have a template for `pipenv`.
 
-If there are other dependency managers you would like to see supported, please let us know in out [github issues](github.com/nitrictech/nitric/issues).
+If there are other dependency managers you would like to see supported, please let us know in our [github issues](github.com/nitrictech/nitric/issues).
 
 </Note>
 

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -189,10 +189,14 @@ Your project should now look like this:
 
 ```txt Python
 +--services/
-|  +-- hello.py
-+--Pipfile
-+--Pipfile.lock
+|  +-- api.py
++--.env
++--pyproject.toml
++--.python-version
++--uv.lock
 +--nitric.yaml
++--python.dockerfile
++--python.dockerfile.dockerignore
 +--README.md
 ```
 


### PR DESCRIPTION
Fix typo in the guides that still use pipenv for the default starter template.