### PR TITLE
Remove `-H` from curl command

### DIFF
--- a/docs/guides/nodejs/secure-api-auth0.mdx
+++ b/docs/guides/nodejs/secure-api-auth0.mdx
@@ -111,7 +111,7 @@ Configure your stack, then run `nitric up` to deploy your application.
 We can check to see if our application is secure by calling it without an `Authorization` header
 
 ```bash
-curl -H <INSERT_API_GATEWAY>/hello/world
+curl <INSERT_API_GATEWAY>/hello/world
 ```
 
 This should return a `401` error.


### PR DESCRIPTION
In the edited curl command, no header is provided to show that the route requires authorization, and thus, no -H flag is needed; if run, it will fail as written.