### PR TITLE
feat: documents the add command

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -21,6 +21,52 @@ There are a few common commands that you will use frequently:
 - `nitric start` runs the Nitric server locally
 - `nitric up` deploys your stack to the cloud
 - `nitric down` destroys your stack from the cloud
+- `nitric add` adds new resources to your project
+
+## Adding Resources
+
+The `add` command helps you add new resources to your project:
+
+```bash
+nitric add
+```
+
+### Adding a Website
+
+To add a new website to your project:
+
+```bash
+nitric add website
+```
+
+This will walk you through an interactive process to:
+
+- Name your website
+- Select a tool/framework (currently supports Astro, Vite, and Hugo)
+- Configure the website's base URL path and dev server port
+
+You can also specify the website name and tool directly:
+
+```bash
+# For Astro
+nitric add website my-site astro
+
+# For Vite
+nitric add website my-site vite
+
+# For Hugo
+nitric add website my-site hugo
+```
+
+### Adding a Stack
+
+The `add stack` command is an alias for `stack new` and can be used to create a new stack:
+
+```bash
+nitric add stack
+```
+
+This will walk you through an interactive process to create a new stack configuration for a particular cloud provider. For more details about stack configuration and options, see the [Stacks section](#stacks) below.
 
 ## Getting Started
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -42,7 +42,7 @@ nitric add website
 This will walk you through an interactive process to:
 
 - Name your website
-- Select a tool/framework (currently supports Astro, Vite, and Hugo)
+- Select a tool/framework (currently supports [Astro](https://astro.build/), [Vite](https://vite.dev/), and [Hugo](https://gohugo.io/))
 - Configure the website's base URL path and dev server port
 
 You can also specify the website name and tool directly:

--- a/docs/websites.mdx
+++ b/docs/websites.mdx
@@ -80,7 +80,7 @@ nitric add website
 This will walk you through an interactive process to:
 
 - Name your website
-- Select a tool/framework (currently supports Astro, Vite, and Hugo)
+- Select a tool/framework (currently supports [Astro](https://astro.build/), [Vite](https://vite.dev/), and [Hugo](https://gohugo.io/))
 - Configure the website's base URL path and dev server port
 
 You can also specify the website name and tool directly:

--- a/docs/websites.mdx
+++ b/docs/websites.mdx
@@ -69,6 +69,39 @@ websites:
       url: http://localhost:4322
 ```
 
+### Alternative: Using the Nitric CLI
+
+You can also add a website to your project using the Nitric CLI's `add website` command:
+
+```bash
+nitric add website
+```
+
+This will walk you through an interactive process to:
+
+- Name your website
+- Select a tool/framework (currently supports Astro, Vite, and Hugo)
+- Configure the website's base URL path and dev server port
+
+You can also specify the website name and tool directly:
+
+```bash
+# For Astro
+nitric add website my-site astro
+
+# For Vite
+nitric add website my-site vite
+
+# For Hugo
+nitric add website my-site hugo
+```
+
+The command will automatically:
+
+1. Create a new website project using the framework's official package manager commands
+2. Add the necessary configuration to your `nitric.yaml` file
+3. Set up the build and development commands using the framework's native tools
+
 ### 3. Start your website locally
 
 Run `nitric start` to start your website locally. This will use the `dev` configuration, which proxies requests to your local development server.


### PR DESCRIPTION
Adds documentation for the new `nitric add` command,
including how to add websites and stacks to a project.

This provides users with clear instructions on how to use
the CLI to scaffold new resources.
